### PR TITLE
Support for delta sharing profile via options

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingClient.scala
@@ -19,9 +19,6 @@ package io.delta.sharing.client
 import java.io.{BufferedReader, InputStreamReader}
 import java.net.{URL, URLEncoder}
 import java.nio.charset.StandardCharsets.UTF_8
-import java.sql.Timestamp
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter.{ISO_DATE, ISO_DATE_TIME}
 import java.util.UUID
 
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
@@ -43,9 +40,21 @@ import org.apache.spark.sql.SparkSession
 import io.delta.sharing.client.auth.{AuthConfig, AuthCredentialProviderFactory}
 import io.delta.sharing.client.model._
 import io.delta.sharing.client.util.{ConfUtils, JsonUtils, RetryUtils, UnexpectedHttpStatus}
+import io.delta.sharing.spark.MissingEndStreamActionException
 
 /** An interface to fetch Delta metadata from remote server. */
 trait DeltaSharingClient {
+
+  protected var dsQueryId: Option[String] = None
+
+  def getQueryId: String = {
+    dsQueryId.getOrElse("dsQueryIdNotSet")
+  }
+
+  protected def getDsQueryIdForLogging: String = {
+    s" for query($dsQueryId)."
+  }
+
   def listAllTables(): Seq[Table]
 
   def getTableVersion(table: Table, startingTimestamp: Option[String] = None): Long
@@ -89,17 +98,15 @@ case class ParsedDeltaSharingTablePath(
  *
  * @param version the table version of the shared table.
  * @param respondedFormat the sharing format (parquet or delta), used to parse the lines.
- * @param includedEndStreamAction whether the last line is required to be an EndStreamAction, parsed
- *                                from the response header.
  * @param lines all lines in the response.
- * @param capabilities value of delta-sharing-capabilities in the response header
+ * @param capabilitiesMap Map parsed from the value of delta-sharing-capabilities in the
+ *                        response header
  */
 case class ParsedDeltaSharingResponse(
     version: Long,
     respondedFormat: String,
-    includedEndStreamAction: Option[Boolean],
     lines: Seq[String],
-    capabilities: Option[String])
+    capabilitiesMap: Map[String, String])
 
 private[sharing] trait PaginationResponse {
   def nextPageToken: Option[String]
@@ -171,15 +178,16 @@ private[sharing] case class ListAllTablesResponse(
 class DeltaSharingRestClient(
     profileProvider: DeltaSharingProfileProvider,
     timeoutInSeconds: Int = 120,
-    numRetries: Int = 10,
+    numRetries: Int = 3,
     maxRetryDuration: Long = Long.MaxValue,
+    retrySleepInterval: Long = 1000,
     sslTrustAll: Boolean = false,
     forStreaming: Boolean = false,
     responseFormat: String = DeltaSharingRestClient.RESPONSE_FORMAT_PARQUET,
     readerFeatures: String = "",
     queryTablePaginationEnabled: Boolean = false,
     maxFilesPerReq: Int = 100000,
-    includeEndStreamAction: Boolean = true,
+    endStreamActionEnabled: Boolean = false,
     enableAsyncQuery: Boolean = false,
     asyncQueryPollIntervalMillis: Long = 10000L,
     asyncQueryMaxDuration: Long = 600000L,
@@ -188,7 +196,7 @@ class DeltaSharingRestClient(
     tokenRenewalThresholdInSeconds: Int = 600
   ) extends DeltaSharingClient with Logging {
 
-  logInfo(s"DeltaSharingRestClient with includeEndStreamAction: $includeEndStreamAction, " +
+  logInfo(s"DeltaSharingRestClient with endStreamActionEnabled: $endStreamActionEnabled, " +
     s"enableAsyncQuery:$enableAsyncQuery")
 
   import DeltaSharingRestClient._
@@ -197,8 +205,6 @@ class DeltaSharingRestClient(
 
   // Convert the responseFormat to a Seq to be used later.
   private val responseFormatSet = responseFormat.split(",").toSet
-
-  private var dsQueryId: Option[String] = None
 
   private lazy val client = {
     val clientBuilder: HttpClientBuilder = if (sslTrustAll) {
@@ -296,10 +302,15 @@ class DeltaSharingRestClient(
     val target =
       getTargetUrl(s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables/" +
         s"$encodedTableName/version$encodedParam")
-    val (version, _, _) = getResponse(new HttpGet(target), true, true)
+    val (version, _, _) = getResponse(
+      new HttpGet(target),
+      allowNoContent = true,
+      fetchAsOneString = true,
+      setIncludeEndStreamAction = false
+    )
     version.getOrElse {
       throw new IllegalStateException(s"Cannot find " +
-        s"${RESPONSE_TABLE_VERSION_HEADER_KEY} in the header")
+        s"${RESPONSE_TABLE_VERSION_HEADER_KEY} in the header," + getDsQueryIdForLogging)
     }
   }
 
@@ -311,10 +322,10 @@ class DeltaSharingRestClient(
   private def checkRespondedFormat(respondedFormat: String, rpc: String, table: String): Unit = {
     if (!responseFormatSet.contains(respondedFormat)) {
       logError(s"RespondedFormat($respondedFormat) is different from requested " +
-        s"responseFormat($responseFormat) for $rpc for table $table.")
+        s"responseFormat($responseFormat) for $rpc for table $table," + getDsQueryIdForLogging)
       throw new IllegalArgumentException("The responseFormat returned from the delta sharing " +
         s"server doesn't match the requested responseFormat: respondedFormat($respondedFormat)" +
-        s" != requestedFormat($responseFormat).")
+        s" != requestedFormat($responseFormat)," + getDsQueryIdForLogging)
     }
   }
 
@@ -330,7 +341,7 @@ class DeltaSharingRestClient(
     val target = getTargetUrl(
       s"/shares/$encodedShareName/schemas/$encodedSchemaName/tables/$encodedTableName/metadata" +
         s"$encodedParams")
-    val response = getNDJson(target)
+    val response = getNDJson(target, requireVersion = true, setIncludeEndStreamAction = false)
 
     checkRespondedFormat(
       response.respondedFormat,
@@ -338,8 +349,8 @@ class DeltaSharingRestClient(
       table = s"${table.share}.${table.schema}.${table.name}"
     )
     if (response.lines.size != 2) {
-      throw new IllegalStateException(s"received more than two lines:${response.lines.size}, " +
-        s"for query($dsQueryId).")
+      throw new IllegalStateException(s"received more than two lines:${response.lines.size}," +
+        getDsQueryIdForLogging)
     }
 
     if (response.respondedFormat == RESPONSE_FORMAT_DELTA) {
@@ -365,7 +376,8 @@ class DeltaSharingRestClient(
     if (protocol.minReaderVersion > DeltaSharingProfile.CURRENT) {
       throw new IllegalArgumentException(s"The table requires a newer version" +
         s" ${protocol.minReaderVersion} to read. But the current release supports version " +
-        s"is ${DeltaSharingProfile.CURRENT} and below. Please upgrade to a newer release.")
+        s"is ${DeltaSharingProfile.CURRENT} and below. Please upgrade to a newer release." +
+        getDsQueryIdForLogging)
     }
   }
 
@@ -440,7 +452,7 @@ class DeltaSharingRestClient(
       if (action.file != null) {
         files.append(action.file)
       } else {
-        throw new IllegalStateException(s"Unexpected Line:${line}")
+        throw new IllegalStateException(s"Unexpected Line:${line}" + getDsQueryIdForLogging)
       }
     }
     DeltaTableFiles(
@@ -458,6 +470,7 @@ class DeltaSharingRestClient(
       startingVersion: Long,
       endingVersion: Option[Long]
   ): DeltaTableFiles = {
+    val start = System.currentTimeMillis()
     val encodedShareName = URLEncoder.encode(table.share, "UTF-8")
     val encodedSchemaName = URLEncoder.encode(table.schema, "UTF-8")
     val encodedTableName = URLEncoder.encode(table.name, "UTF-8")
@@ -481,13 +494,18 @@ class DeltaSharingRestClient(
     val (version, respondedFormat, lines) = if (queryTablePaginationEnabled) {
       logInfo(
         s"Making paginated queryTable from version $startingVersion requests for table " +
-        s"${table.share}.${table.schema}.${table.name} with maxFiles=$maxFilesPerReq"
+        s"${table.share}.${table.schema}.${table.name} with maxFiles=$maxFilesPerReq, " +
+          getDsQueryIdForLogging
       )
       val (version, respondedFormat, lines, _) = getFilesByPage(table, target, request)
       (version, respondedFormat, lines)
     } else {
-      val response = getNDJson(target, request)
+      val response = getNDJsonPost(
+        target = target, data = request, setIncludeEndStreamAction = endStreamActionEnabled
+      )
       val (filteredLines, _) = maybeExtractEndStreamAction(response.lines)
+      logInfo(s"Took ${System.currentTimeMillis() - start} ms to query ${filteredLines.size} " +
+        s"files for [$startingVersion, $endingVersion]," + getDsQueryIdForLogging)
       (response.version, response.respondedFormat, filteredLines)
     }
 
@@ -512,7 +530,8 @@ class DeltaSharingRestClient(
         case a: AddFileForCDF => addFiles.append(a)
         case r: RemoveFile => removeFiles.append(r)
         case m: Metadata => additionalMetadatas.append(m)
-        case _ => throw new IllegalStateException(s"Unexpected Line:${line}")
+        case _ => throw new IllegalStateException(
+          s"Unexpected Line:${line}" + getDsQueryIdForLogging)
       }
     }
     DeltaTableFiles(
@@ -539,14 +558,16 @@ class DeltaSharingRestClient(
     val (version, respondedFormat, lines, queryIdOpt) = if (enableAsyncQuery) {
       getNDJsonWithAsync(table, targetUrl, request)
     } else {
-      val response = getNDJson(targetUrl, request)
+      val response = getNDJsonPost(
+        target = targetUrl, data = request, setIncludeEndStreamAction = endStreamActionEnabled
+      )
       (response.version, response.respondedFormat, response.lines, None)
     }
 
     var (filteredLines, endStreamAction) = maybeExtractEndStreamAction(lines)
     if (endStreamAction.isEmpty) {
       logWarning(
-        s"EndStreamAction is not returned in the response for paginated query($dsQueryId)."
+        s"EndStreamAction is not returned in the paginated response" + getDsQueryIdForLogging
       )
     }
 
@@ -593,24 +614,27 @@ class DeltaSharingRestClient(
         expectedRespondedFormat = respondedFormat,
         expectedProtocol = protocol,
         expectedMetadata = metadata,
-        pageNumber = numPages
+        pageNumber = numPages,
+        // Do not set EndStreamAction for async queries yet, and set it for sync queries.
+        setIncludeEndStreamAction = !enableAsyncQuery
       )
       allLines.appendAll(res._1)
       endStreamAction = res._2
       if (endStreamAction.isEmpty) {
         logWarning(
-          s"EndStreamAction is not returned in the response for paginated query($dsQueryId)."
+          s"EndStreamAction is not returned in the paginated response" + getDsQueryIdForLogging
         )
       }
       // Throw an error if the first page is expiring before we get all pages
       if (minUrlExpirationTimestamp.exists(_ <= System.currentTimeMillis())) {
-        throw new IllegalStateException("Unable to fetch all pages before minimum url expiration.")
+        throw new IllegalStateException(
+          "Unable to fetch all pages before minimum url expiration." + getDsQueryIdForLogging
+        )
       }
     }
 
-    // TODO: remove logging once changes are rolled out
     logInfo(s"Took ${System.currentTimeMillis() - start} ms to query $numPages pages " +
-      s"of ${allLines.size} files")
+      s"of ${allLines.size} files," + getDsQueryIdForLogging)
     (version, respondedFormat, allLines.toSeq, refreshToken)
   }
 
@@ -626,14 +650,16 @@ class DeltaSharingRestClient(
     val target = getTargetUrl(
       s"/shares/$encodedShare/schemas/$encodedSchema/tables/$encodedTable/changes?$encodedParams")
     val (version, respondedFormat, lines) = if (queryTablePaginationEnabled) {
-      // TODO: remove logging once changes are rolled out
       logInfo(
         s"Making paginated queryTableChanges requests for table " +
-          s"${table.share}.${table.schema}.${table.name} with maxFiles=$maxFilesPerReq"
+          s"${table.share}.${table.schema}.${table.name} with maxFiles=$maxFilesPerReq, " +
+          getDsQueryIdForLogging
       )
       getCDFFilesByPage(target)
     } else {
-      val response = getNDJson(target, requireVersion = false)
+      val response = getNDJson(
+        target, requireVersion = false, setIncludeEndStreamAction = endStreamActionEnabled
+      )
       val (filteredLines, _) = maybeExtractEndStreamAction(response.lines)
       (response.version, response.respondedFormat, filteredLines)
     }
@@ -663,7 +689,8 @@ class DeltaSharingRestClient(
         case a: AddFileForCDF => addFiles.append(a)
         case r: RemoveFile => removeFiles.append(r)
         case m: Metadata => additionalMetadatas.append(m)
-        case _ => throw new IllegalStateException(s"Unexpected Line:${line}")
+        case _ => throw new IllegalStateException(
+          s"Unexpected Line:${line}," + getDsQueryIdForLogging)
       }
     }
     DeltaTableFiles(
@@ -687,11 +714,13 @@ class DeltaSharingRestClient(
 
     // Fetch first page
     var updatedUrl = s"$targetUrl&maxFiles=$maxFilesPerReq"
-    val response = getNDJson(updatedUrl, requireVersion = false)
+    val response = getNDJson(
+      updatedUrl, requireVersion = false, setIncludeEndStreamAction = endStreamActionEnabled
+    )
     var (filteredLines, endStreamAction) = maybeExtractEndStreamAction(response.lines)
     if (endStreamAction.isEmpty) {
       logWarning(
-        s"EndStreamAction is not returned in the response for paginated query($dsQueryId)."
+        s"EndStreamAction is not returned in the paginated response" + getDsQueryIdForLogging
       )
     }
     val protocol = filteredLines(0)
@@ -715,25 +744,27 @@ class DeltaSharingRestClient(
         expectedRespondedFormat = response.respondedFormat,
         expectedProtocol = protocol,
         expectedMetadata = metadata,
-        pageNumber = numPages
+        pageNumber = numPages,
+        setIncludeEndStreamAction = endStreamActionEnabled
       )
       allLines.appendAll(res._1)
       endStreamAction = res._2
       if (endStreamAction.isEmpty) {
         logWarning(
-          s"EndStreamAction is not returned in the response for paginated query($dsQueryId)."
+          s"EndStreamAction is not returned in the paginated response" + getDsQueryIdForLogging
         )
       }
       // Throw an error if the first page is expiring before we get all pages
       if (minUrlExpirationTimestamp.exists(_ <= System.currentTimeMillis())) {
-        throw new IllegalStateException("Unable to fetch all pages before minimum url expiration.")
+        throw new IllegalStateException(
+          "Unable to fetch all pages before minimum url expiration," + getDsQueryIdForLogging
+        )
       }
     }
 
-    // TODO: remove logging once changes are rolled out
     logInfo(
       s"Took ${System.currentTimeMillis() - start} ms to query $numPages pages " +
-      s"of ${allLines.size} files"
+      s"of ${allLines.size} files," + getDsQueryIdForLogging
     )
     (response.version, response.respondedFormat, allLines.toSeq)
   }
@@ -748,15 +779,23 @@ class DeltaSharingRestClient(
       expectedRespondedFormat: String,
       expectedProtocol: String,
       expectedMetadata: String,
-      pageNumber: Int): (Seq[String], Option[EndStreamAction]) = {
+      pageNumber: Int,
+      setIncludeEndStreamAction: Boolean): (Seq[String], Option[EndStreamAction]) = {
     val start = System.currentTimeMillis()
     val response = if (requestBody.isDefined) {
-      getNDJson(targetUrl, requestBody.get)
+      getNDJsonPost(
+        target = targetUrl,
+        data = requestBody.get,
+        setIncludeEndStreamAction = setIncludeEndStreamAction
+      )
     } else {
-      getNDJson(targetUrl, requireVersion = false)
+      getNDJson(
+        target = targetUrl,
+        requireVersion = false,
+        setIncludeEndStreamAction = setIncludeEndStreamAction)
     }
     logInfo(s"Took ${System.currentTimeMillis() - start} to fetch ${pageNumber}th page " +
-      s"of ${response.lines.size} lines.")
+      s"of ${response.lines.size} lines," + getDsQueryIdForLogging)
 
     // Validate that version/format/protocol/metadata in the response don't change across pages
     if (response.version != expectedVersion ||
@@ -768,7 +807,7 @@ class DeltaSharingRestClient(
         |Received inconsistent version/format/protocol/metadata across pages.
         |Expected: version $expectedVersion, $expectedRespondedFormat,
         |$expectedProtocol, $expectedMetadata. Actual: version ${response.version},
-        |${response.respondedFormat}, ${response.lines}""".stripMargin
+        |${response.respondedFormat}, ${response.lines},$getDsQueryIdForLogging""".stripMargin
       logError(s"Error while fetching next page files at url $targetUrl " +
         s"with body(${JsonUtils.toJson(requestBody.orNull)}: $errorMsg)")
       throw new IllegalStateException(errorMsg)
@@ -818,25 +857,26 @@ class DeltaSharingRestClient(
   }
 
   private def getNDJson(
-      target: String, requireVersion: Boolean = true): ParsedDeltaSharingResponse = {
-    val (version, capabilities, lines) = getResponse(new HttpGet(target))
-    val (respondedFormat, includedEndStreamAction) = getRespondedHeaders(capabilities)
+      target: String,
+      requireVersion: Boolean,
+      setIncludeEndStreamAction: Boolean): ParsedDeltaSharingResponse = {
+    val (version, capabilitiesMap, lines) = getResponse(
+      new HttpGet(target), setIncludeEndStreamAction = setIncludeEndStreamAction
+    )
 
     val response = ParsedDeltaSharingResponse(
       version = version.getOrElse {
         if (requireVersion) {
           throw new IllegalStateException(s"Cannot find " +
-            s"${RESPONSE_TABLE_VERSION_HEADER_KEY} in the header")
+            s"${RESPONSE_TABLE_VERSION_HEADER_KEY} in the header" + getDsQueryIdForLogging)
         } else {
           0L
         }
       },
-      respondedFormat = respondedFormat,
-      includedEndStreamAction = includedEndStreamAction,
+      respondedFormat = getRespondedFormat(capabilitiesMap),
       lines,
-      capabilities = capabilities
+      capabilitiesMap = capabilitiesMap
     )
-    checkEndStreamAction(response)
     response
   }
 
@@ -861,7 +901,9 @@ class DeltaSharingRestClient(
       maxFiles = maxFiles,
       pageToken = pageToken)
 
-    val response = getNDJson(target, request)
+    val response = getNDJsonPost(
+      target = target, data = request, setIncludeEndStreamAction = false
+    )
     (response.version, response.respondedFormat, response.lines)
   }
 
@@ -900,7 +942,9 @@ class DeltaSharingRestClient(
       target: String,
       request: QueryTableRequest): (Long, String, Seq[String], Option[String]) = {
     // Initial query to get NDJson data
-    val response = getNDJson(target, request)
+    val response = getNDJsonPost(
+      target = target, data = request, setIncludeEndStreamAction = false
+    )
 
     // Check if the query is still pending
     var (lines, queryIdOpt, queryPending) = checkQueryPending(response.lines)
@@ -938,65 +982,71 @@ class DeltaSharingRestClient(
     (version, respondedFormat, lines, queryIdOpt)
   }
 
-  private def getNDJson[T: Manifest](target: String, data: T): ParsedDeltaSharingResponse = {
+  private def getNDJsonPost[T: Manifest](
+      target: String,
+      data: T,
+      setIncludeEndStreamAction: Boolean): ParsedDeltaSharingResponse = {
     val httpPost = new HttpPost(target)
     val json = JsonUtils.toJson(data)
     httpPost.setHeader("Content-type", "application/json")
     httpPost.setEntity(new StringEntity(json, UTF_8))
-    val (version, capabilities, lines) = getResponse(httpPost)
-    val (respondedFormat, includedEndStreamAction) = getRespondedHeaders(capabilities)
+    val (version, capabilitiesMap, lines) = getResponse(
+      httpPost, setIncludeEndStreamAction = setIncludeEndStreamAction
+    )
 
     val response = ParsedDeltaSharingResponse(
       version = version.getOrElse {
-        throw new IllegalStateException("Cannot find Delta-Table-Version in the header")
+        throw new IllegalStateException(
+          "Cannot find Delta-Table-Version in the header" + getDsQueryIdForLogging
+        )
       },
-      respondedFormat = respondedFormat,
-      includedEndStreamAction = includedEndStreamAction,
+      respondedFormat = getRespondedFormat(capabilitiesMap),
       lines,
-      capabilities = capabilities
+      capabilitiesMap = capabilitiesMap
     )
-    checkEndStreamAction(response)
     response
   }
 
-  private def checkEndStreamAction(response: ParsedDeltaSharingResponse): Unit = {
-    if (includeEndStreamAction) {
-      // Only perform additional check when includeEndStreamAction = true
-      response.includedEndStreamAction match {
-        case Some(true) =>
-          val lastLineAction = JsonUtils.fromJson[SingleAction](response.lines.last)
-          if (lastLineAction.endStreamAction == null) {
-            throw new IllegalStateException(s"Client sets " +
-              s"${DELTA_SHARING_END_STREAM_ACTION}=true in the " +
-              s"header, server responded with the header set to true(${response.capabilities}, " +
-              s"and ${response.lines.size} lines, and last line parsed as " +
-              s"${lastLineAction.unwrap.getClass()}, for query($dsQueryId).")
-          }
-          logInfo(
-            s"Successfully verified endStreamAction in the response for query($dsQueryId)."
-          )
-        case Some(false) =>
-          logWarning(s"Client sets ${DELTA_SHARING_END_STREAM_ACTION}=true in the " +
-            s"header, but the server responded with the header set to false(" +
-            s"${response.capabilities}), for query($dsQueryId)."
-          )
-        case None =>
-          logWarning(s"Client sets ${DELTA_SHARING_END_STREAM_ACTION}=true in the" +
-              s" header, but server didn't respond with the header(${response.capabilities}) " +
-              s"for query($dsQueryId)."
-          )
-      }
+  private def checkEndStreamAction(
+      capabilities: Option[String],
+      capabilitiesMap: Map[String, String],
+      lines: Seq[String]): Unit = {
+    val includeEndStreamActionHeader = getRespondedIncludeEndStreamActionHeader(capabilitiesMap)
+    includeEndStreamActionHeader match {
+      case Some(true) =>
+        val lastLineAction = JsonUtils.fromJson[SingleAction](lines.last)
+        if (lastLineAction.endStreamAction == null) {
+          throw new MissingEndStreamActionException(s"Client sets " +
+            s"${DELTA_SHARING_INCLUDE_END_STREAM_ACTION}=true in the " +
+            s"header, server responded with the header set to true(${capabilities}, " +
+            s"and ${lines.size} lines, and last line parsed as " +
+            s"${lastLineAction.unwrap.getClass()}," + getDsQueryIdForLogging)
+        }
+        logInfo(
+          s"Successfully verified endStreamAction in the response" + getDsQueryIdForLogging
+        )
+      case Some(false) =>
+        logWarning(s"Client sets ${DELTA_SHARING_INCLUDE_END_STREAM_ACTION}=true in the " +
+          s"header, but the server responded with the header set to false(" +
+          s"${capabilities})," + getDsQueryIdForLogging
+        )
+      case None =>
+        logWarning(s"Client sets ${DELTA_SHARING_INCLUDE_END_STREAM_ACTION}=true in the" +
+          s" header, but server didn't respond with the header(${capabilities}), " +
+          getDsQueryIdForLogging
+        )
     }
   }
 
-  private def getRespondedHeaders(capabilities: Option[String]): (String, Option[Boolean]) = {
-    val capabilitiesMap = parseDeltaSharingCapabilities(capabilities)
-    val includedEndStreamActionOpt = capabilitiesMap
-      .get(DELTA_SHARING_END_STREAM_ACTION)
-    (
-      capabilitiesMap.get(RESPONSE_FORMAT).getOrElse(RESPONSE_FORMAT_PARQUET),
-      includedEndStreamActionOpt.map(_.toBoolean)
-    )
+  private def getRespondedFormat(capabilitiesMap: Map[String, String]): String = {
+    capabilitiesMap.get(RESPONSE_FORMAT).getOrElse(RESPONSE_FORMAT_PARQUET)
+  }
+
+  // includeEndStreamActionHeader indicates whether the last line is required to be an
+  // EndStreamAction, parsed from the response header.
+  private def getRespondedIncludeEndStreamActionHeader(
+      capabilitiesMap: Map[String, String]): Option[Boolean] = {
+    capabilitiesMap.get(DELTA_SHARING_INCLUDE_END_STREAM_ACTION).map(_.toBoolean)
   }
 
   private def parseDeltaSharingCapabilities(capabilities: Option[String]): Map[String, String] = {
@@ -1012,10 +1062,15 @@ class DeltaSharingRestClient(
   }
 
   private def getJson[R: Manifest](target: String): R = {
-    val (_, _, response) = getResponse(new HttpGet(target), false, true)
+    val (_, _, response) = getResponse(
+      new HttpGet(target),
+      allowNoContent = false,
+      fetchAsOneString = true,
+      setIncludeEndStreamAction = false
+    )
     if (response.size != 1) {
       throw new IllegalStateException(
-        "Unexpected response for target: " +  target + ", response=" + response
+        s"Unexpected response for target:$target, response=$response" + getDsQueryIdForLogging
       )
     }
     JsonUtils.fromJson[R](response(0))
@@ -1036,7 +1091,8 @@ class DeltaSharingRestClient(
     authCredentialProvider.isExpired()
   }
 
-  private[client] def prepareHeaders(httpRequest: HttpRequestBase): HttpRequestBase = {
+  private[client] def prepareHeaders(
+      httpRequest: HttpRequestBase, setIncludeEndStreamAction: Boolean): HttpRequestBase = {
     val customeHeaders = profileProvider.getCustomHeaders
     if (customeHeaders.contains(HttpHeaders.AUTHORIZATION)
       || customeHeaders.contains(HttpHeaders.USER_AGENT)) {
@@ -1047,7 +1103,9 @@ class DeltaSharingRestClient(
     }
     val headers = Map(
       HttpHeaders.USER_AGENT -> getUserAgent(),
-      DELTA_SHARING_CAPABILITIES_HEADER -> constructDeltaSharingCapabilities()
+      DELTA_SHARING_CAPABILITIES_HEADER -> constructDeltaSharingCapabilities(
+        setIncludeEndStreamAction
+      )
     ) ++ customeHeaders
     headers.foreach(header => httpRequest.setHeader(header._1, header._2))
     authCredentialProvider.addAuthHeader(httpRequest)
@@ -1067,15 +1125,16 @@ class DeltaSharingRestClient(
   private def getResponse(
       httpRequest: HttpRequestBase,
       allowNoContent: Boolean = false,
-      fetchAsOneString: Boolean = false
-  ): (Option[Long], Option[String], Seq[String]) = {
+      fetchAsOneString: Boolean = false,
+      setIncludeEndStreamAction: Boolean = false
+  ): (Option[Long], Map[String, String], Seq[String]) = {
     // Reset dsQueryId before calling RetryUtils, and before prepareHeaders.
     dsQueryId = Some(UUID.randomUUID().toString().split('-').head)
-    RetryUtils.runWithExponentialBackoff(numRetries, maxRetryDuration) {
+    RetryUtils.runWithExponentialBackoff(numRetries, maxRetryDuration, retrySleepInterval) {
       val profile = profileProvider.getProfile
       val response = client.execute(
         getHttpHost(profile.endpoint),
-        prepareHeaders(httpRequest),
+        prepareHeaders(httpRequest, setIncludeEndStreamAction = setIncludeEndStreamAction),
         HttpClientContext.create()
       )
       try {
@@ -1103,7 +1162,8 @@ class DeltaSharingRestClient(
             }
           } catch {
             case e: org.apache.http.ConnectionClosedException =>
-              val error = s"Request to delta sharing server failed due to ${e}."
+              val error = s"Request to delta sharing server failed$getDsQueryIdForLogging " +
+                s"due to ${e}."
               logError(error)
               lineBuffer += error
               lineBuffer.toList
@@ -1118,21 +1178,27 @@ class DeltaSharingRestClient(
           var additionalErrorInfo = ""
           if (statusCode == HttpStatus.SC_UNAUTHORIZED && tokenExpired()) {
             additionalErrorInfo = s"It may be caused by an expired token as it has expired " +
-              s"at ${authCredentialProvider.getExpirationTime()}"
+              s"at ${authCredentialProvider.getExpirationTime()}."
           }
           // Only show the last 100 lines in the error to keep it contained.
           val responseToShow = lines.drop(lines.size - 100).mkString("\n")
           throw new UnexpectedHttpStatus(
-            s"HTTP request failed with status: $status $responseToShow. $additionalErrorInfo",
+            s"HTTP request failed with status: $status" +
+              Seq(getDsQueryIdForLogging, additionalErrorInfo, responseToShow).mkString(" "),
             statusCode)
+        }
+        val capabilities = Option(
+          response.getFirstHeader(DELTA_SHARING_CAPABILITIES_HEADER)
+        ).map(_.getValue)
+        val capabilitiesMap = parseDeltaSharingCapabilities(capabilities)
+        if (setIncludeEndStreamAction) {
+          checkEndStreamAction(capabilities, capabilitiesMap, lines)
         }
         (
           Option(
             response.getFirstHeader(RESPONSE_TABLE_VERSION_HEADER_KEY)
           ).map(_.getValue.toLong),
-          Option(
-            response.getFirstHeader(DELTA_SHARING_CAPABILITIES_HEADER)
-          ).map(_.getValue),
+          capabilitiesMap,
           lines
         )
       } finally {
@@ -1159,18 +1225,18 @@ class DeltaSharingRestClient(
   // The value for delta-sharing-capabilities header, semicolon separated capabilities.
   // Each capability is in the format of "key=value1,value2", values are separated by comma.
   // Example: "capability1=value1;capability2=value3,value4,value5"
-  private def constructDeltaSharingCapabilities(): String = {
+  private def constructDeltaSharingCapabilities(setIncludeEndStreamAction: Boolean): String = {
     var capabilities = Seq[String](s"${RESPONSE_FORMAT}=$responseFormat")
     if (responseFormatSet.contains(RESPONSE_FORMAT_DELTA) && readerFeatures.nonEmpty) {
       capabilities = capabilities :+ s"$READER_FEATURES=$readerFeatures"
     }
 
     if (enableAsyncQuery) {
-     capabilities = capabilities :+ s"$DELTA_SHARING_CAPABILITIES_ASYNC_READ=true"
+      capabilities = capabilities :+ s"$DELTA_SHARING_CAPABILITIES_ASYNC_READ=true"
     }
 
-    if (includeEndStreamAction) {
-      capabilities = capabilities :+ s"$DELTA_SHARING_END_STREAM_ACTION=true"
+    if (setIncludeEndStreamAction) {
+      capabilities = capabilities :+ s"$DELTA_SHARING_INCLUDE_END_STREAM_ACTION=true"
     }
 
     val cap = capabilities.mkString(DELTA_SHARING_CAPABILITIES_DELIMITER)
@@ -1195,7 +1261,7 @@ object DeltaSharingRestClient extends Logging {
   val RESPONSE_FORMAT = "responseformat"
   val READER_FEATURES = "readerfeatures"
   val DELTA_SHARING_CAPABILITIES_ASYNC_READ = "asyncquery"
-  val DELTA_SHARING_END_STREAM_ACTION = "endstreamaction"
+  val DELTA_SHARING_INCLUDE_END_STREAM_ACTION = "includeendstreamaction"
   val RESPONSE_FORMAT_DELTA = "delta"
   val RESPONSE_FORMAT_PARQUET = "parquet"
   val DELTA_SHARING_CAPABILITIES_DELIMITER = ";"
@@ -1239,17 +1305,29 @@ object DeltaSharingRestClient extends Logging {
    * Parse the user provided path `profile_file#share.schema.table` to
    * ParsedDeltaSharingTablePath.
    */
-  def parsePath(path: String): ParsedDeltaSharingTablePath = {
+  def parsePath(
+     path: String,
+     shareCredentialsOptions: Map[String, String]): ParsedDeltaSharingTablePath = {
     val shapeIndex = path.lastIndexOf('#')
-    if (shapeIndex < 0) {
-      throw new IllegalArgumentException(s"path $path is not valid")
+
+    val (profileFile, tablePath) = {
+      if (shareCredentialsOptions.nonEmpty && shapeIndex < 0) {
+        ("", path)
+      } else if (shareCredentialsOptions.nonEmpty && shapeIndex >= 0) {
+          throw new IllegalArgumentException(
+            "cannot specify both share credentials options and a profile file path")
+      } else if (shareCredentialsOptions.isEmpty && shapeIndex < 0) {
+          throw new IllegalArgumentException(s"path $path is not valid")
+      } else {
+          (path.substring(0, shapeIndex), path.substring(shapeIndex + 1))
+      }
     }
-    val profileFile = path.substring(0, shapeIndex)
-    val tableSplits = path.substring(shapeIndex + 1).split("\\.", -1)
+
+    val tableSplits = tablePath.split("\\.", -1)
     if (tableSplits.length != 3) {
       throw new IllegalArgumentException(s"path $path is not valid")
     }
-    if (profileFile.isEmpty || tableSplits(0).isEmpty ||
+    if ((profileFile.isEmpty && shareCredentialsOptions.isEmpty) || tableSplits(0).isEmpty ||
       tableSplits(1).isEmpty || tableSplits(2).isEmpty) {
       throw new IllegalArgumentException(s"path $path is not valid")
     }
@@ -1263,29 +1341,34 @@ object DeltaSharingRestClient extends Logging {
 
   def apply(
       profileFile: String,
+      shareCredentialsOptions: Map[String, String],
       forStreaming: Boolean = false,
       responseFormat: String = RESPONSE_FORMAT_PARQUET,
       readerFeatures: String = ""
   ): DeltaSharingClient = {
     val sqlConf = SparkSession.active.sessionState.conf
 
-    val profileProviderClass = ConfUtils.profileProviderClass(sqlConf)
-    val profileProvider: DeltaSharingProfileProvider =
+    val profileProvider: DeltaSharingProfileProvider = if (shareCredentialsOptions.nonEmpty) {
+        new DeltaSharingOptionsProfileProvider(shareCredentialsOptions)
+    } else {
+      val profileProviderClass = ConfUtils.profileProviderClass(sqlConf)
       Class.forName(profileProviderClass)
         .getConstructor(classOf[Configuration], classOf[String])
         .newInstance(SparkSession.active.sessionState.newHadoopConf(),
           profileFile)
         .asInstanceOf[DeltaSharingProfileProvider]
+    }
 
     // This is a flag to test the local https server. Should never be used in production.
     val sslTrustAll = ConfUtils.sslTrustAll(sqlConf)
     val numRetries = ConfUtils.numRetries(sqlConf)
     val maxRetryDurationMillis = ConfUtils.maxRetryDurationMillis(sqlConf)
+    val retrySleepIntervalMillis = ConfUtils.retrySleepIntervalMillis(sqlConf)
     val timeoutInSeconds = ConfUtils.timeoutInSeconds(sqlConf)
     val queryTablePaginationEnabled = ConfUtils.queryTablePaginationEnabled(sqlConf)
     val maxFilesPerReq = ConfUtils.maxFilesPerQueryRequest(sqlConf)
     val useAsyncQuery = ConfUtils.useAsyncQuery(sqlConf)
-    val includeEndStreamAction = ConfUtils.includeEndStreamAction(sqlConf)
+    val endStreamActionEnabled = ConfUtils.includeEndStreamAction(sqlConf)
     val asyncQueryMaxDurationMillis = ConfUtils.asyncQueryTimeout(sqlConf)
     val asyncQueryPollDurationMillis = ConfUtils.asyncQueryPollIntervalMillis(sqlConf)
 
@@ -1300,6 +1383,7 @@ object DeltaSharingRestClient extends Logging {
         classOf[DeltaSharingProfileProvider],
         classOf[Int],
         classOf[Int],
+        classOf[Long],
         classOf[Long],
         classOf[Boolean],
         classOf[Boolean],
@@ -1318,13 +1402,14 @@ object DeltaSharingRestClient extends Logging {
         java.lang.Integer.valueOf(timeoutInSeconds),
         java.lang.Integer.valueOf(numRetries),
         java.lang.Long.valueOf(maxRetryDurationMillis),
+        java.lang.Long.valueOf(retrySleepIntervalMillis),
         java.lang.Boolean.valueOf(sslTrustAll),
         java.lang.Boolean.valueOf(forStreaming),
         responseFormat,
         readerFeatures,
         java.lang.Boolean.valueOf(queryTablePaginationEnabled),
         java.lang.Integer.valueOf(maxFilesPerReq),
-        java.lang.Boolean.valueOf(includeEndStreamAction),
+        java.lang.Boolean.valueOf(endStreamActionEnabled),
         java.lang.Boolean.valueOf(useAsyncQuery),
         java.lang.Long.valueOf(asyncQueryPollDurationMillis),
         java.lang.Long.valueOf(asyncQueryMaxDurationMillis),

--- a/client/src/main/scala/io/delta/sharing/client/DeltaSharingProfileProvider.scala
+++ b/client/src/main/scala/io/delta/sharing/client/DeltaSharingProfileProvider.scala
@@ -41,7 +41,7 @@ sealed trait DeltaSharingProfile {
   private [client] def validate(): Unit = {
     if (shareCredentialsVersion.isEmpty) {
       throw new IllegalArgumentException(
-        "Cannot find the 'shareCredentialsVersion' field in the profile file")
+        "Cannot find the 'shareCredentialsVersion' field in the profile")
     }
 
     if (shareCredentialsVersion.get > DeltaSharingProfile.CURRENT) {
@@ -143,14 +143,14 @@ object DeltaSharingProfile {
   private [client] def validateNotNullAndEmpty(fieldValue: String,
                                                fieldName: String): Unit = {
     if (fieldValue == null || fieldValue.isEmpty) {
-      throw new IllegalArgumentException(s"Cannot find the '$fieldName' field in the profile file")
+      throw new IllegalArgumentException(s"Cannot find the '$fieldName' field in the profile")
     }
   }
 
   private [client] def validateNotNullAndEmpty(fieldValue: Option[Long],
                                                fieldName: String): Unit = {
     if (fieldValue == null || fieldValue.isEmpty) {
-      throw new IllegalArgumentException(s"Cannot find the '$fieldName' field in the profile file")
+      throw new IllegalArgumentException(s"Cannot find the '$fieldName' field in the profile")
     }
   }
 }
@@ -192,6 +192,24 @@ private[sharing] class DeltaSharingFileProfileProvider(
       input.close()
     }
 
+    profile.validate()
+
+    profile
+  }
+
+  override def getProfile: DeltaSharingProfile = profile
+}
+
+/**
+ * Load [[DeltaSharingProfile]] from options.
+ */
+private[sharing] class DeltaSharingOptionsProfileProvider(
+    shareCredentialsOptions: Map[String, String]) extends DeltaSharingProfileProvider {
+
+  val profile = {
+    val profile = {
+      JsonUtils.fromJson[DeltaSharingProfile](JsonUtils.toJson(shareCredentialsOptions))
+    }
     profile.validate()
 
     profile

--- a/client/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/DeltaSharingOptions.scala
@@ -105,6 +105,8 @@ trait DeltaSharingReadOptions extends DeltaSharingOptionParser {
     str
   }.getOrElse(RESPONSE_FORMAT_PARQUET)
 
+  val shareCredentialsOptions: Map[String, String] = prepareShareCredentialsOptions()
+
   def isTimeTravel: Boolean = versionAsOf.isDefined || timestampAsOf.isDefined
 
   // Parse the input timestamp string and TimestampType, and generate a formatted timestamp string
@@ -131,6 +133,21 @@ trait DeltaSharingReadOptions extends DeltaSharingOptionParser {
       )
     } else {
      Map.empty[String, String]
+    }
+  }
+
+  private def prepareShareCredentialsOptions(): Map[String, String] = {
+    validShareCredentialsOptions.filter { option =>
+      options.contains(option._1)
+    }.map { option =>
+      val key = option._1
+      val value = key match {
+        case PROFILE_EXPIRATION_TIME =>
+          getFormattedTimestamp(options.get(key).get)
+        case _ =>
+          options.get(key).get
+      }
+      key -> value
     }
   }
 
@@ -193,9 +210,18 @@ object DeltaSharingOptions extends Logging {
   val TIME_TRAVEL_TIMESTAMP = "timestampAsOf"
 
   val RESPONSE_FORMAT = "responseFormat"
-
   val RESPONSE_FORMAT_PARQUET = "parquet"
   val RESPONSE_FORMAT_DELTA = "delta"
+
+  val PROFILE_SHARE_CREDENTIALS_VERSION = "shareCredentialsVersion"
+  val PROFILE_TYPE = "shareCredentialsType"
+  val PROFILE_ENDPOINT = "endpoint"
+  val PROFILE_TOKEN_ENDPOINT = "tokenEndpoint"
+  val PROFILE_CLIENT_ID = "clientId"
+  val PROFILE_CLIENT_SECRET = "clientSecret"
+  val PROFILE_SCOPE = "scope"
+  val PROFILE_BEARER_TOKEN = "bearerToken"
+  val PROFILE_EXPIRATION_TIME = "expirationTime"
 
   val validCdfOptions = Map(
     CDF_READ_OPTION -> "",
@@ -204,6 +230,18 @@ object DeltaSharingOptions extends Logging {
     CDF_END_TIMESTAMP -> "",
     CDF_START_VERSION -> "",
     CDF_END_VERSION -> ""
+  )
+
+  val validShareCredentialsOptions = Map(
+    PROFILE_SHARE_CREDENTIALS_VERSION -> "",
+    PROFILE_TYPE -> "",
+    PROFILE_ENDPOINT -> "",
+    PROFILE_TOKEN_ENDPOINT -> "",
+    PROFILE_CLIENT_ID -> "",
+    PROFILE_CLIENT_SECRET -> "",
+    PROFILE_SCOPE -> "",
+    PROFILE_BEARER_TOKEN -> "",
+    PROFILE_EXPIRATION_TIME -> ""
   )
 }
 

--- a/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
+++ b/client/src/main/scala/io/delta/sharing/spark/RemoteDeltaLog.scala
@@ -51,6 +51,7 @@ import io.delta.sharing.client.model.{
 }
 import io.delta.sharing.client.util.ConfUtils
 import io.delta.sharing.spark.perf.DeltaSharingLimitPushDown
+import io.delta.sharing.spark.util.SchemaUtils
 
 /**
  * Used to query the current state of the transaction logs of a remote shared Delta table.
@@ -139,11 +140,13 @@ private[sharing] object RemoteDeltaLog {
 
   def apply(
       path: String,
+      shareCredentialsOptions: Map[String, String],
       forStreaming: Boolean = false,
       responseFormat: String = DeltaSharingOptions.RESPONSE_FORMAT_PARQUET,
       initDeltaTableMetadata: Option[DeltaTableMetadata] = None): RemoteDeltaLog = {
-    val parsedPath = DeltaSharingRestClient.parsePath(path)
-    val client = DeltaSharingRestClient(parsedPath.profileFile, forStreaming, responseFormat)
+    val parsedPath = DeltaSharingRestClient.parsePath(path, shareCredentialsOptions)
+    val client = DeltaSharingRestClient(
+      parsedPath.profileFile, shareCredentialsOptions, forStreaming, responseFormat)
     val deltaSharingTable = DeltaSharingTable(
       name = parsedPath.table,
       schema = parsedPath.schema,
@@ -227,11 +230,23 @@ class RemoteSnapshot(
   }
 
   private def checkSchemaNotChange(newMetadata: Metadata): Unit = {
-    if (newMetadata.schemaString != metadata.schemaString ||
+    val schemaChangedException = new SparkException(
+      s"""The schema or partition columns of your Delta table has changed since your
+         |DataFrame was created. Please redefine your DataFrame""".stripMargin)
+
+    if (ConfUtils.structuralSchemaMatchingEnabled(spark.sessionState.conf)) {
+      val newSchema = DataType.fromJson(newMetadata.schemaString).asInstanceOf[StructType]
+      val currentSchema = DataType.fromJson(metadata.schemaString).asInstanceOf[StructType]
+
+      if (
+        metadata.partitionColumns != newMetadata.partitionColumns ||
+          !SchemaUtils.isReadCompatible(currentSchema, newSchema)
+      ) {
+        throw schemaChangedException
+      }
+    } else if (newMetadata.schemaString != metadata.schemaString ||
       newMetadata.partitionColumns != metadata.partitionColumns) {
-      throw new SparkException(
-        s"""The schema or partition columns of your Delta table has changed since your
-           |DataFrame was created. Please redefine your DataFrame""")
+      throw schemaChangedException
     }
   }
 

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingRestClientSuite.scala
@@ -40,29 +40,38 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
   import DeltaSharingRestClient._
 
   test("parsePath") {
-    assert(DeltaSharingRestClient.parsePath("file:///foo/bar#a.b.c") ==
+    val emptyShareCredentialsOptions: Map[String, String] = Map.empty
+    val testShareCredentialsOptions: Map[String, String] = Map("key" -> "value")
+
+    assert(
+      DeltaSharingRestClient.parsePath("file:///foo/bar#a.b.c", emptyShareCredentialsOptions) ==
       ParsedDeltaSharingTablePath("file:///foo/bar", "a", "b", "c"))
-    assert(DeltaSharingRestClient.parsePath("file:///foo/bar#bar#a.b.c") ==
+    assert(DeltaSharingRestClient.parsePath("file:///foo/bar#bar#a.b.c", emptyShareCredentialsOptions) ==
       ParsedDeltaSharingTablePath("file:///foo/bar#bar", "a", "b", "c"))
-    assert(DeltaSharingRestClient.parsePath("file:///foo/bar#bar#a.b.c ") ==
+    assert(DeltaSharingRestClient.parsePath("file:///foo/bar#bar#a.b.c ", emptyShareCredentialsOptions) ==
       ParsedDeltaSharingTablePath("file:///foo/bar#bar", "a", "b", "c "))
+    assert(DeltaSharingRestClient.parsePath("a.b.c", testShareCredentialsOptions) ==
+      ParsedDeltaSharingTablePath("", "a", "b", "c"))
     intercept[IllegalArgumentException] {
-      DeltaSharingRestClient.parsePath("file:///foo/bar")
+      DeltaSharingRestClient.parsePath("file:///foo/barr#a.b.c ", testShareCredentialsOptions)
     }
     intercept[IllegalArgumentException] {
-      DeltaSharingRestClient.parsePath("file:///foo/bar#a.b")
+      DeltaSharingRestClient.parsePath("file:///foo/bar", emptyShareCredentialsOptions)
     }
     intercept[IllegalArgumentException] {
-      DeltaSharingRestClient.parsePath("file:///foo/bar#a.b.c.d")
+      DeltaSharingRestClient.parsePath("file:///foo/bar#a.b", emptyShareCredentialsOptions)
     }
     intercept[IllegalArgumentException] {
-      DeltaSharingRestClient.parsePath("#a.b.c")
+      DeltaSharingRestClient.parsePath("file:///foo/bar#a.b.c.d", emptyShareCredentialsOptions)
     }
     intercept[IllegalArgumentException] {
-      DeltaSharingRestClient.parsePath("foo#a.b.")
+      DeltaSharingRestClient.parsePath("#a.b.c", emptyShareCredentialsOptions)
     }
     intercept[IllegalArgumentException] {
-      DeltaSharingRestClient.parsePath("foo#a.b.c.")
+      DeltaSharingRestClient.parsePath("foo#a.b.", emptyShareCredentialsOptions)
+    }
+    intercept[IllegalArgumentException] {
+      DeltaSharingRestClient.parsePath("foo#a.b.c.", emptyShareCredentialsOptions)
     }
   }
 
@@ -84,37 +93,65 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
       assert(h.contains(" java/"))
     }
 
-    def checkDeltaSharingCapabilities(request: HttpRequestBase, expected: String): Unit = {
+    def getEndStreamActionHeader(endStreamActionEnabled: Boolean): String = {
+      if (endStreamActionEnabled) {
+        s";$DELTA_SHARING_INCLUDE_END_STREAM_ACTION=true"
+      } else {
+        ""
+      }
+    }
+
+    def checkDeltaSharingCapabilities(
+      request: HttpRequestBase,
+      responseFormat: String,
+      readerFeatures: String,
+      endStreamActionEnabled: Boolean): Unit = {
+      val expected = s"${RESPONSE_FORMAT}=$responseFormat$readerFeatures" +
+        getEndStreamActionHeader(endStreamActionEnabled)
       val h = request.getFirstHeader(DELTA_SHARING_CAPABILITIES_HEADER)
       assert(h.getValue == expected)
     }
 
-    var httpRequestBase = new DeltaSharingRestClient(
-      testProfileProvider, forStreaming = false, readerFeatures = "willBeIgnored").prepareHeaders(httpRequest)
-    checkUserAgent(httpRequestBase, false)
-    checkDeltaSharingCapabilities(httpRequestBase, s"${RESPONSE_FORMAT}=parquet;$DELTA_SHARING_END_STREAM_ACTION=true")
+    Seq(
+      (true, true),
+      (true, false),
+      (false, true),
+      (false, false)
+    ).foreach { case (forStreaming, endStreamActionEnabled) =>
+      var client = new DeltaSharingRestClient(
+        testProfileProvider,
+        forStreaming = forStreaming,
+        endStreamActionEnabled = endStreamActionEnabled,
+        readerFeatures = "willBeIgnored")
+        .prepareHeaders(httpRequest, setIncludeEndStreamAction = endStreamActionEnabled)
+      checkUserAgent(client, forStreaming)
+      checkDeltaSharingCapabilities(client, "parquet", "", endStreamActionEnabled)
 
-    val readerFeatures = "deletionVectors,columnMapping,timestampNTZ"
-    httpRequestBase = new DeltaSharingRestClient(
-      testProfileProvider,
-      forStreaming = true,
-      responseFormat = RESPONSE_FORMAT_DELTA,
-      readerFeatures = readerFeatures).prepareHeaders(httpRequest)
-    checkUserAgent(httpRequestBase, true)
-    checkDeltaSharingCapabilities(
-      httpRequestBase, s"$RESPONSE_FORMAT=delta;$READER_FEATURES=$readerFeatures;$DELTA_SHARING_END_STREAM_ACTION=true"
-    )
+      val readerFeatures = "deletionVectors,columnMapping,timestampNTZ"
+      client = new DeltaSharingRestClient(
+        testProfileProvider,
+        forStreaming = forStreaming,
+        endStreamActionEnabled = endStreamActionEnabled,
+        responseFormat = RESPONSE_FORMAT_DELTA,
+        readerFeatures = readerFeatures)
+        .prepareHeaders(httpRequest, setIncludeEndStreamAction = endStreamActionEnabled)
+      checkUserAgent(client, forStreaming)
+      checkDeltaSharingCapabilities(
+        client, "delta", s";$READER_FEATURES=$readerFeatures", endStreamActionEnabled
+      )
 
-    httpRequestBase = new DeltaSharingRestClient(
-      testProfileProvider,
-      forStreaming = true,
-      responseFormat = s"$RESPONSE_FORMAT_DELTA,$RESPONSE_FORMAT_PARQUET",
-      readerFeatures = readerFeatures,
-      includeEndStreamAction = false).prepareHeaders(httpRequest)
-    checkUserAgent(httpRequestBase, true)
-    checkDeltaSharingCapabilities(
-      httpRequestBase, s"responseformat=delta,parquet;readerfeatures=$readerFeatures"
-    )
+      client = new DeltaSharingRestClient(
+        testProfileProvider,
+        forStreaming = forStreaming,
+        endStreamActionEnabled = endStreamActionEnabled,
+        responseFormat = s"$RESPONSE_FORMAT_DELTA,$RESPONSE_FORMAT_PARQUET",
+        readerFeatures = readerFeatures)
+        .prepareHeaders(httpRequest, setIncludeEndStreamAction = endStreamActionEnabled)
+      checkUserAgent(client, forStreaming)
+      checkDeltaSharingCapabilities(
+        client, s"delta,parquet", s";$READER_FEATURES=$readerFeatures", endStreamActionEnabled
+      )
+    }
   }
 
   integrationTest("listAllTables") {
@@ -1105,7 +1142,8 @@ class DeltaSharingRestClientSuite extends DeltaSharingIntegrationTest {
               false
             )
           }.getMessage
-          assert(errorMessage.contains("""400 Bad Request {"errorCode":"RESOURCE_DOES_NOT_EXIST""""))
+          assert(errorMessage.contains("""400 Bad Request for query"""))
+          assert(errorMessage.contains("""{"errorCode":"RESOURCE_DOES_NOT_EXIST""""))
           assert(errorMessage.contains("table files missing"))
         } finally {
           client.close()

--- a/client/src/test/scala/io/delta/sharing/spark/DeltaSharingOptionsSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/spark/DeltaSharingOptionsSuite.scala
@@ -83,6 +83,41 @@ class DeltaSharingOptionsSuite extends SparkFunSuite {
     assert(options.options.get("notreservedoption") == Some("random"))
   }
 
+  test("Parse shareCredentials map successfully") {
+    // profile as opts
+    var options = new DeltaSharingOptions(Map(
+      "shareCredentialsVersion" -> "1",
+      "shareCredentialsType" -> "bearer_token",
+      "endpoint" -> "foo",
+      "tokenEndpoint" -> "bar",
+      "clientId" -> "abc",
+      "clientSecret" -> "xyz",
+      "scope" -> "testScope",
+      "bearerToken" -> "bar",
+      "expirationTime" -> "2022-01-01T00:00:00-02:00"
+    ))
+
+    assert(options.shareCredentialsOptions.get(
+      DeltaSharingOptions.PROFILE_SHARE_CREDENTIALS_VERSION) == Some("1"))
+    assert(options.shareCredentialsOptions.get(
+      DeltaSharingOptions.PROFILE_TYPE) == Some("bearer_token"))
+    assert(options.shareCredentialsOptions.get(
+      DeltaSharingOptions.PROFILE_ENDPOINT) == Some("foo"))
+    assert(options.shareCredentialsOptions.get(
+      DeltaSharingOptions.PROFILE_TOKEN_ENDPOINT) == Some("bar"))
+    assert(options.shareCredentialsOptions.get(
+      DeltaSharingOptions.PROFILE_CLIENT_ID) == Some("abc"))
+    assert(options.shareCredentialsOptions.get(
+      DeltaSharingOptions.PROFILE_CLIENT_SECRET) == Some("xyz"))
+    assert(options.shareCredentialsOptions.get(
+      DeltaSharingOptions.PROFILE_SCOPE) == Some("testScope"))
+    assert(options.shareCredentialsOptions.get(
+      DeltaSharingOptions.PROFILE_BEARER_TOKEN) == Some("bar"))
+    assert(options.shareCredentialsOptions.get(
+      DeltaSharingOptions.PROFILE_EXPIRATION_TIME) == Some("2022-01-01T02:00:00Z"))
+
+  }
+
   test("Parse cdfOptions map successfully") {
     var options = new DeltaSharingOptions(Map(
       "readChangeFeed" -> "true",

--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -72,30 +72,42 @@ def get_table_version(
     return response.delta_table_version
 
 
-def get_table_protocol(url: str) -> Protocol:
+def __get_table_metadata(rest_client: DataSharingRestClient, table: Table, use_delta_format: bool):
+    if use_delta_format:
+        rest_client.set_sharing_capabilities_header()
+        response = rest_client.query_table_metadata(table)
+        rest_client.remove_sharing_capabilities_header()
+    else:
+        response = rest_client.query_table_metadata(table)
+    return response
+
+
+def get_table_protocol(url: str, use_delta_format: bool = True) -> Protocol:
     """
     Get the shared table protocol using the given url.
 
     :param url: a url under the format "<profile>#<share>.<schema>.<table>"
     """
-    profile_json, share, schema, table = _parse_url(url)
+    profile_json, share, schema, table_name = _parse_url(url)
     profile = DeltaSharingProfile.read_from_file(profile_json)
     rest_client = DataSharingRestClient(profile)
-    response = rest_client.query_table_metadata(Table(name=table, share=share, schema=schema))
-    return response.protocol
+    table = Table(name=table_name, share=share, schema=schema)
+    full_metadata = __get_table_metadata(rest_client, table, use_delta_format)
+    return full_metadata.protocol
 
 
-def get_table_metadata(url: str) -> Metadata:
+def get_table_metadata(url: str, use_delta_format: bool = True) -> Metadata:
     """
     Get the shared table metadata using the given url.
 
     :param url: a url under the format "<profile>#<share>.<schema>.<table>"
     """
-    profile_json, share, schema, table = _parse_url(url)
+    profile_json, share, schema, table_name = _parse_url(url)
     profile = DeltaSharingProfile.read_from_file(profile_json)
     rest_client = DataSharingRestClient(profile)
-    response = rest_client.query_table_metadata(Table(name=table, share=share, schema=schema))
-    return response.metadata
+    table = Table(name=table_name, share=share, schema=schema)
+    full_metadata = __get_table_metadata(rest_client, table, use_delta_format)
+    return full_metadata.metadata
 
 
 def load_as_pandas(
@@ -134,7 +146,8 @@ def load_as_pandas(
 def load_as_spark(
     url: str,
     version: Optional[int] = None,
-    timestamp: Optional[str] = None
+    timestamp: Optional[str] = None,
+    delta_sharing_profile: Optional[DeltaSharingProfile] = None
 ) -> "PySparkDataFrame":  # noqa: F821
     """
     Load the shared table using the given url as a Spark DataFrame. `PySpark` must be installed,
@@ -142,9 +155,14 @@ def load_as_spark(
     Sharing installed. Only one of version/timestamp is supported at one time.
 
     :param url: a url under the format "<profile>#<share>.<schema>.<table>".
+    :type url: str
     :param version: an optional non-negative int. Load the snapshot of table at version.
+    :type version: Optional[int]
     :param timestamp: an optional string. Load the snapshot of table at version corresponding
       to the timestamp.
+    :type timestamp: Optional[str]
+    :param delta_sharing_profile: The DeltaSharingProfile to use for the connection
+    :type delta_sharing_profile: Optional[DeltaSharingProfile]
     :return: A Spark DataFrame representing the shared table.
     """
     try:
@@ -158,6 +176,25 @@ def load_as_spark(
         "`load_as_spark` requires running in a PySpark application."
     )
     df = spark.read.format("deltaSharing")
+    if delta_sharing_profile is not None:
+        if delta_sharing_profile.share_credentials_version is not None:
+            df.option("shareCredentialsVersion", delta_sharing_profile.share_credentials_version)
+        if delta_sharing_profile.type is not None:
+            df.option("shareCredentialsType", delta_sharing_profile.type)
+        if delta_sharing_profile.endpoint is not None:
+            df.option("endpoint", delta_sharing_profile.endpoint)
+        if delta_sharing_profile.token_endpoint is not None:
+            df.option("tokenEndpoint", delta_sharing_profile.token_endpoint)
+        if delta_sharing_profile.client_id is not None:
+            df.option("clientId", delta_sharing_profile.client_id)
+        if delta_sharing_profile.client_secret is not None:
+            df.option("clientSecret", delta_sharing_profile.client_secret)
+        if delta_sharing_profile.scope is not None:
+            df.option("scope", delta_sharing_profile.scope)
+        if delta_sharing_profile.bearer_token is not None:
+            df.option("bearerToken", delta_sharing_profile.bearer_token)
+        if delta_sharing_profile.expiration_time is not None:
+            df.option("expirationTime", delta_sharing_profile.expiration_time)
     if version is not None:
         df.option("versionAsOf", version)
     if timestamp is not None:
@@ -170,7 +207,8 @@ def load_table_changes_as_spark(
     starting_version: Optional[int] = None,
     ending_version: Optional[int] = None,
     starting_timestamp: Optional[str] = None,
-    ending_timestamp: Optional[str] = None
+    ending_timestamp: Optional[str] = None,
+    delta_sharing_profile: Optional[DeltaSharingProfile] = None
 ) -> "PySparkDataFrame":  # noqa: F821
     """
     Load the table changes of a shared table as a Spark DataFrame using the given url.
@@ -181,10 +219,17 @@ def load_table_changes_as_spark(
     latest table version for it. The parameter range is inclusive in the query.
 
     :param url: a url under the format "<profile>#<share>.<schema>.<table>".
+    :type url: str
     :param starting_version: The starting version of table changes.
+    :type starting_version: Optional[int]
     :param ending_version: The ending version of table changes.
+    :type ending_version: Optional[int]
     :param starting_timestamp: The starting timestamp of table changes.
+    :type starting_timestamp: Optional[str]
     :param ending_timestamp: The ending timestamp of table changes.
+    :type ending_timestamp: Optional[str]
+    :param delta_sharing_profile: The DeltaSharingProfile to use for the connection
+    :type delta_sharing_profile: Optional[DeltaSharingProfile]
     :return: A Spark DataFrame representing the table changes.
     """
     try:
@@ -199,6 +244,25 @@ def load_table_changes_as_spark(
         "`load_table_changes_as_spark` requires running in a PySpark application."
     )
     df = spark.read.format("deltaSharing").option("readChangeFeed", "true")
+    if delta_sharing_profile is not None:
+        if delta_sharing_profile.share_credentials_version is not None:
+            df.option("shareCredentialsVersion", delta_sharing_profile.share_credentials_version)
+        if delta_sharing_profile.type is not None:
+            df.option("shareCredentialsType", delta_sharing_profile.type)
+        if delta_sharing_profile.endpoint is not None:
+            df.option("endpoint", delta_sharing_profile.endpoint)
+        if delta_sharing_profile.token_endpoint is not None:
+            df.option("tokenEndpoint", delta_sharing_profile.token_endpoint)
+        if delta_sharing_profile.client_id is not None:
+            df.option("clientId", delta_sharing_profile.client_id)
+        if delta_sharing_profile.client_secret is not None:
+            df.option("clientSecret", delta_sharing_profile.client_secret)
+        if delta_sharing_profile.scope is not None:
+            df.option("scope", delta_sharing_profile.scope)
+        if delta_sharing_profile.bearer_token is not None:
+            df.option("bearerToken", delta_sharing_profile.bearer_token)
+        if delta_sharing_profile.expiration_time is not None:
+            df.option("expirationTime", delta_sharing_profile.expiration_time)
     if starting_version is not None:
         df.option("startingVersion", starting_version)
     if ending_version is not None:
@@ -215,7 +279,8 @@ def load_table_changes_as_pandas(
     starting_version: Optional[int] = None,
     ending_version: Optional[int] = None,
     starting_timestamp: Optional[str] = None,
-    ending_timestamp: Optional[str] = None
+    ending_timestamp: Optional[str] = None,
+    use_delta_format: Optional[bool] = None
 ) -> pd.DataFrame:
     """
     Load the table changes of shared table as a pandas DataFrame using the given url.
@@ -235,11 +300,15 @@ def load_table_changes_as_pandas(
     return DeltaSharingReader(
         table=Table(name=table, share=share, schema=schema),
         rest_client=DataSharingRestClient(profile),
+        use_delta_format=use_delta_format
     ).table_changes_to_pandas(CdfOptions(
         starting_version=starting_version,
         ending_version=ending_version,
         starting_timestamp=starting_timestamp,
         ending_timestamp=ending_timestamp,
+        # when using delta format, we need to get metadata changes and
+        # handle them properly when replaying the delta log
+        include_historical_metadata=use_delta_format
     ))
 
 

--- a/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
+++ b/spark/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
@@ -48,7 +48,8 @@ private[sharing] class DeltaSharingDataSource
     val path = options.options.getOrElse("path", throw DeltaSharingErrors.pathNotSpecifiedException)
 
     val deltaLog = RemoteDeltaLog(
-      path, forStreaming = false, responseFormat = options.responseFormat
+      path, options.shareCredentialsOptions,
+      forStreaming = false, responseFormat = options.responseFormat
     )
     deltaLog.createRelation(options.versionAsOf, options.timestampAsOf, options.cdfOptions)
   }
@@ -69,7 +70,8 @@ private[sharing] class DeltaSharingDataSource
 
     val path = options.options.getOrElse("path", throw DeltaSharingErrors.pathNotSpecifiedException)
     val deltaLog = RemoteDeltaLog(
-      path, forStreaming = true, responseFormat = options.responseFormat
+      path, options.shareCredentialsOptions,
+      forStreaming = true, responseFormat = options.responseFormat
     )
     val schemaToUse = deltaLog.snapshot().schema
     if (schemaToUse.isEmpty) {
@@ -95,7 +97,9 @@ private[sharing] class DeltaSharingDataSource
     }
     val options = new DeltaSharingOptions(parameters)
     val path = options.options.getOrElse("path", throw DeltaSharingErrors.pathNotSpecifiedException)
-    val deltaLog = RemoteDeltaLog(path, forStreaming = true, options.responseFormat)
+    val deltaLog = RemoteDeltaLog(
+      path, options.shareCredentialsOptions, forStreaming = true, options.responseFormat
+    )
 
     DeltaSharingSource(SparkSession.active, deltaLog, options)
   }

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceCDFSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceCDFSuite.scala
@@ -40,6 +40,7 @@ class DeltaSharingSourceCDFSuite extends QueryTest
   with SharedSparkSession with DeltaSharingIntegrationTest {
 
   import testImplicits._
+  lazy val shareCredentialsOptions: Map[String, String] = Map.empty
 
   // VERSION 0: CREATE TABLE
   // VERSION 1: INSERT 3 rows, 3 add files
@@ -66,7 +67,7 @@ class DeltaSharingSourceCDFSuite extends QueryTest
   // VERSION 4: REMOVE 4 rows, 2 remove files
   lazy val cdfTablePath = testProfileFile.getCanonicalPath + "#share8.default.streaming_cdf_table"
 
-  lazy val deltaLog = RemoteDeltaLog(cdfTablePath, forStreaming = true)
+  lazy val deltaLog = RemoteDeltaLog(cdfTablePath, shareCredentialsOptions, forStreaming = true)
 
   def getSource(parameters: Map[String, String]): DeltaSharingSource = {
     val options = new DeltaSharingOptions(parameters ++ Map("readChangeFeed" -> "true"))

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceParamsSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceParamsSuite.scala
@@ -26,6 +26,7 @@ class DeltaSharingSourceParamsSuite extends QueryTest
   with SharedSparkSession with DeltaSharingIntegrationTest {
 
   import testImplicits._
+  lazy val shareCredentialsOptions: Map[String, String] = Map.empty
 
   // VERSION 0: CREATE TABLE
   // VERSION 1: INSERT 3 rows, 3 add files
@@ -33,7 +34,7 @@ class DeltaSharingSourceParamsSuite extends QueryTest
   // VERSION 3: UPDATE 1 row, 1 remove file and 1 add file
   lazy val tablePath = testProfileFile.getCanonicalPath + "#share8.default.cdf_table_cdf_enabled"
 
-  lazy val deltaLog = RemoteDeltaLog(tablePath, forStreaming = true)
+  lazy val deltaLog = RemoteDeltaLog(tablePath, shareCredentialsOptions, forStreaming = true)
 
   def getSource(parameters: Map[String, String]): DeltaSharingSource = {
     val options = new DeltaSharingOptions(parameters)

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSourceSuite.scala
@@ -42,6 +42,7 @@ class DeltaSharingSourceSuite extends QueryTest
   //   https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html
 
   import testImplicits._
+  lazy val shareCredentialsOptions: Map[String, String] = Map.empty
 
   // VERSION 0: CREATE TABLE
   // VERSION 1: INSERT 3 rows, 3 add files
@@ -67,7 +68,7 @@ class DeltaSharingSourceSuite extends QueryTest
   lazy val toNotNullTable = testProfileFile.getCanonicalPath +
     "#share8.default.streaming_null_to_notnull"
 
-  lazy val deltaLog = RemoteDeltaLog(tablePath, forStreaming = true)
+  lazy val deltaLog = RemoteDeltaLog(tablePath, shareCredentialsOptions, forStreaming = true)
 
   def getSource(parameters: Map[String, String]): DeltaSharingSource = {
     val options = new DeltaSharingOptions(parameters)

--- a/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
+++ b/spark/src/test/scala/io/delta/sharing/spark/DeltaSharingSuite.scala
@@ -34,6 +34,24 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
 
   import testImplicits._
 
+  integrationTest("table1 passing profile with read options") {
+    val tablePath = "share1.default.table1"
+    val expected = Seq(
+      Row(sqlTimestamp("2021-04-27 23:32:02.07"), sqlDate("2021-04-28")),
+      Row(sqlTimestamp("2021-04-27 23:32:22.421"), sqlDate("2021-04-28"))
+    )
+    val readOptions = Map(
+      "endpoint" -> "https://localhost:$TEST_PORT/delta-sharing",
+      "bearerToken" -> "dapi5e3574ec767ca1548ae5bbed1a2dc04d",
+      "shareCredentialsVersion" -> "1"
+    )
+    checkAnswer(spark.read.format("deltaSharing").options(readOptions).load(tablePath), expected)
+    withTable("delta_sharing_test") {
+      sql(s"CREATE TABLE delta_sharing_test USING deltaSharing LOCATION '$tablePath'")
+      checkAnswer(sql(s"SELECT * FROM delta_sharing_test"), expected)
+    }
+  }
+
   integrationTest("table1") {
     val tablePath = testProfileFile.getCanonicalPath + "#share1.default.table1"
     val expected = Seq(
@@ -448,7 +466,8 @@ class DeltaSharingSuite extends QueryTest with SharedSparkSession with DeltaShar
         .option("startingVersion", 0).load(tablePath)
       checkAnswer(df, Nil)
     }
-    assert (ex.getMessage.contains("""400 Bad Request {"errorCode":"RESOURCE_DOES_NOT_EXIST""""))
+    assert (ex.getMessage.contains("""400 Bad Request"""))
+    assert (ex.getMessage.contains("""{"errorCode":"RESOURCE_DOES_NOT_EXIST""""))
   }
 
   integrationTest("azure support") {


### PR DESCRIPTION
<div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances the Delta Sharing Client by adding support for configuring delta sharing profiles via options in both Scala and Python components. It improves error handling with new logging utilities to capture query IDs and refines retry configurations for better robustness. The changes also update method signatures and streamline profile provider integration.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 5
</div>