### PR TITLE
Enable Support for Custom Session+Proxy Configurations

### DIFF
--- a/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
+++ b/client/src/main/scala/io/delta/sharing/client/util/ConfUtils.scala
@@ -16,8 +16,8 @@
 
 package io.delta.sharing.client.util
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import java.util.concurrent.TimeUnit
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.internal.SQLConf
@@ -81,6 +81,10 @@ object ConfUtils {
   val PROXY_PORT = "spark.delta.sharing.network.proxyPort"
   val NO_PROXY_HOSTS = "spark.delta.sharing.network.noProxyHosts"
 
+  val CUSTOM_HEADERS = "spark.delta.sharing.network.customHeaders"
+  val PROXY_AUTH_TOKEN = "spark.delta.sharing.network.proxyAuthToken"
+  val CA_CERT_PATH = "spark.delta.sharing.network.caCertPath"
+
   val OAUTH_RETRIES_CONF = "spark.delta.sharing.oauth.tokenExchangeMaxRetries"
   val OAUTH_RETRIES_DEFAULT = 5
 
@@ -108,8 +112,40 @@ object ConfUtils {
     val proxyPort = proxyPortAsString.toInt
     validatePortNumber(proxyPort, PROXY_PORT)
 
-    val noProxyList = conf.getTrimmedStrings(NO_PROXY_HOSTS).toSeq
-    Some(ProxyConfig(proxyHost, proxyPort, noProxyHosts = noProxyList))
+    Some(ProxyConfig(
+      host = proxyHost,
+      port = proxyPort,
+      noProxyHosts = conf.getTrimmedStrings(NO_PROXY_HOSTS).toSeq,
+      authToken = Option(conf.get(PROXY_AUTH_TOKEN, null)),
+      caCertPath = Option(conf.get(CA_CERT_PATH, null)),
+      sslTrustAll = conf.getBoolean(SSL_TRUST_ALL_CONF, SSL_TRUST_ALL_DEFAULT.toBoolean)
+    ))
+  }
+
+
+  def getCustomHeaders(conf: Configuration): Option[Map[String, String]] = {
+    val headersString = conf.get(CUSTOM_HEADERS, null)
+    if (headersString != null && headersString.nonEmpty) {
+      val mapper = new ObjectMapper()
+      val headers = mapper.readValue(headersString, classOf[Map[String, String]])
+      Some(headers)
+    } else {
+      None
+    }
+  }
+
+  def validateCustomHeaders(headers: Map[String, String]): Unit = {
+    headers.foreach { case (key, value) =>
+      require(key != null && key.nonEmpty, "Custom header name must not be null or empty")
+      require(value != null, s"Custom header value for '$key' must not be null")
+    }
+  }
+
+  def getTimeoutInMillis(conf: Configuration): Int = {
+    val timeoutStr = conf.get(TIMEOUT_CONF, TIMEOUT_DEFAULT)
+    val timeoutMillis = JavaUtils.timeStringAs(timeoutStr, TimeUnit.MILLISECONDS)
+    validateNonNeg(timeoutMillis, TIMEOUT_CONF)
+    timeoutMillis.toInt
   }
 
   def getNeverUseHttps(conf: Configuration): Boolean = {
@@ -325,7 +361,10 @@ object ConfUtils {
   }
 
   case class ProxyConfig(host: String,
-                         port: Int,
-                         noProxyHosts: Seq[String] = Seq.empty
+                          port: Int,
+                          noProxyHosts: Seq[String] = Seq.empty,
+                          authToken: Option[String] = None,
+                          caCertPath: Option[String] = None,
+                          sslTrustAll: Boolean = false
                         )
 }

--- a/client/src/test/scala/io/delta/sharing/client/DeltaSharingFileSystemSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/DeltaSharingFileSystemSuite.scala
@@ -92,11 +92,13 @@ class DeltaSharingFileSystemSuite extends SparkFunSuite {
     proxyServer.initialize()
 
     try {
-
       // Create a ProxyConfig with the host and port of the local proxy server.
       val conf = new Configuration
       conf.set(ConfUtils.PROXY_HOST, proxyServer.getHost())
       conf.set(ConfUtils.PROXY_PORT, proxyServer.getPort().toString)
+      conf.set(ConfUtils.PROXY_AUTH_TOKEN, "testAuthToken")
+      conf.set(ConfUtils.CA_CERT_PATH, "/path/to/ca_cert.pem")
+      conf.set(ConfUtils.SSL_TRUST_ALL_CONF, "true")
 
       // Configure the httpClient to use the ProxyConfig.
       val fs = new DeltaSharingFileSystem() {

--- a/client/src/test/scala/io/delta/sharing/client/util/ConfUtilsSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/util/ConfUtilsSuite.scala
@@ -113,13 +113,19 @@ class ConfUtilsSuite extends SparkFunSuite {
     val conf = newConf(Map(
       PROXY_HOST -> "1.2.3.4",
       PROXY_PORT -> "8080",
-      NO_PROXY_HOSTS -> "localhost,127.0.0.1"
+      NO_PROXY_HOSTS -> "localhost,127.0.0.1",
+      PROXY_AUTH_TOKEN -> "testAuthToken",
+      CA_CERT_PATH -> "/path/to/ca_cert.pem",
+      SSL_TRUST_ALL_CONF -> "true"
     ))
     val proxyConfig = getProxyConfig(conf)
     assert(proxyConfig.isDefined)
     assert(proxyConfig.get.host == "1.2.3.4")
     assert(proxyConfig.get.port == 8080)
     assert(proxyConfig.get.noProxyHosts == Seq("localhost", "127.0.0.1"))
+    assert(proxyConfig.get.authToken.contains("testAuthToken"))
+    assert(proxyConfig.get.caCertPath.contains("/path/to/ca_cert.pem"))
+    assert(proxyConfig.get.sslTrustAll)
   }
 
   test("getProxyConfig with only host and port") {
@@ -132,6 +138,9 @@ class ConfUtilsSuite extends SparkFunSuite {
     assert(proxyConfig.get.host == "1.2.3.4")
     assert(proxyConfig.get.port == 8080)
     assert(proxyConfig.get.noProxyHosts.isEmpty)
+    assert(proxyConfig.get.authToken.isEmpty)
+    assert(proxyConfig.get.caCertPath.isEmpty)
+    assert(!proxyConfig.get.sslTrustAll)
   }
 
   test("getProxyConfig with no proxy settings") {

--- a/client/src/test/scala/io/delta/sharing/client/util/RetryUtilsSuite.scala
+++ b/client/src/test/scala/io/delta/sharing/client/util/RetryUtilsSuite.scala
@@ -22,7 +22,6 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.SparkFunSuite
 
-import io.delta.sharing.client.util.{RetryUtils, UnexpectedHttpStatus}
 import io.delta.sharing.client.util.RetryUtils._
 import io.delta.sharing.spark.MissingEndStreamActionException
 

--- a/python/delta_sharing/delta_sharing.py
+++ b/python/delta_sharing/delta_sharing.py
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from itertools import chain
-from typing import BinaryIO, List, Optional, Sequence, TextIO, Tuple, Union
-from pathlib import Path
+from typing import Optional, Tuple
 
 import pandas as pd
 
@@ -26,11 +24,10 @@ try:
 except ImportError:
     pass
 
-from delta_sharing.protocol import DeltaSharingProfile, Schema, Share, Table
+from delta_sharing.sharing_client import SharingClient
+from delta_sharing.protocol import DeltaSharingProfile, Table
 from delta_sharing.reader import DeltaSharingReader
 from delta_sharing.rest_client import DataSharingRestClient
-
-from requests.exceptions import HTTPError
 
 
 def _parse_url(url: str) -> Tuple[str, str, str, str]:
@@ -105,6 +102,7 @@ def load_as_pandas(
     timestamp: Optional[str] = None,
     jsonPredicateHints: Optional[str] = None,
     use_delta_format: Optional[bool] = None,
+    sharing_client: Optional[SharingClient] = None,
 ) -> pd.DataFrame:
     """
     Load the shared table using the given url as a pandas DataFrame.
@@ -120,9 +118,10 @@ def load_as_pandas(
     """
     profile_json, share, schema, table = _parse_url(url)
     profile = DeltaSharingProfile.read_from_file(profile_json)
+    rest_client = (sharing_client and sharing_client.rest_client) or DataSharingRestClient(profile)
     return DeltaSharingReader(
         table=Table(name=table, share=share, schema=schema),
-        rest_client=DataSharingRestClient(profile),
+        rest_client=rest_client,
         jsonPredicateHints=jsonPredicateHints,
         limit=limit,
         version=version,
@@ -216,7 +215,8 @@ def load_table_changes_as_pandas(
     ending_version: Optional[int] = None,
     starting_timestamp: Optional[str] = None,
     ending_timestamp: Optional[str] = None,
-    use_delta_format: Optional[bool] = None
+    use_delta_format: Optional[bool] = None,
+    sharing_client: Optional[SharingClient] = None,
 ) -> pd.DataFrame:
     """
     Load the table changes of shared table as a pandas DataFrame using the given url.
@@ -233,9 +233,10 @@ def load_table_changes_as_pandas(
     """
     profile_json, share, schema, table = _parse_url(url)
     profile = DeltaSharingProfile.read_from_file(profile_json)
+    rest_client = (sharing_client and sharing_client.rest_client) or DataSharingRestClient(profile)
     return DeltaSharingReader(
         table=Table(name=table, share=share, schema=schema),
-        rest_client=DataSharingRestClient(profile),
+        rest_client=rest_client,
         use_delta_format=use_delta_format
     ).table_changes_to_pandas(CdfOptions(
         starting_version=starting_version,
@@ -246,89 +247,3 @@ def load_table_changes_as_pandas(
         # handle them properly when replaying the delta log
         include_historical_metadata=use_delta_format
     ))
-
-
-class SharingClient:
-    """
-    A Delta Sharing client to query shares/schemas/tables from a Delta Sharing Server.
-    """
-
-    def __init__(self, profile: Union[str, BinaryIO, TextIO, Path, DeltaSharingProfile]):
-        if not isinstance(profile, DeltaSharingProfile):
-            profile = DeltaSharingProfile.read_from_file(profile)
-        self._profile = profile
-        self._rest_client = DataSharingRestClient(profile)
-
-    def __list_all_tables_in_share(self, share: Share) -> Sequence[Table]:
-        tables: List[Table] = []
-        page_token: Optional[str] = None
-        while True:
-            response = self._rest_client.list_all_tables(share=share, page_token=page_token)
-            tables.extend(response.tables)
-            page_token = response.next_page_token
-            if page_token is None or page_token == "":
-                return tables
-
-    def list_shares(self) -> Sequence[Share]:
-        """
-        List shares that can be accessed by you in a Delta Sharing Server.
-
-        :return: the shares that can be accessed.
-        """
-        shares: List[Share] = []
-        page_token: Optional[str] = None
-        while True:
-            response = self._rest_client.list_shares(page_token=page_token)
-            shares.extend(response.shares)
-            page_token = response.next_page_token
-            if page_token is None or page_token == "":
-                return shares
-
-    def list_schemas(self, share: Share) -> Sequence[Schema]:
-        """
-        List schemas in a share that can be accessed by you in a Delta Sharing Server.
-
-        :param share: the share to list.
-        :return: the schemas in a share.
-        """
-        schemas: List[Schema] = []
-        page_token: Optional[str] = None
-        while True:
-            response = self._rest_client.list_schemas(share=share, page_token=page_token)
-            schemas.extend(response.schemas)
-            page_token = response.next_page_token
-            if page_token is None or page_token == "":
-                return schemas
-
-    def list_tables(self, schema: Schema) -> Sequence[Table]:
-        """
-        List tables in a schema that can be accessed by you in a Delta Sharing Server.
-
-        :param schema: the schema to list.
-        :return: the tables in a schema.
-        """
-        tables: List[Table] = []
-        page_token: Optional[str] = None
-        while True:
-            response = self._rest_client.list_tables(schema=schema, page_token=page_token)
-            tables.extend(response.tables)
-            page_token = response.next_page_token
-            if page_token is None or page_token == "":
-                return tables
-
-    def list_all_tables(self) -> Sequence[Table]:
-        """
-        List all tables that can be accessed by you in a Delta Sharing Server.
-
-        :return: all tables that can be accessed.
-        """
-        shares = self.list_shares()
-        try:
-            return list(chain(*(self.__list_all_tables_in_share(share) for share in shares)))
-        except HTTPError as e:
-            if e.response.status_code == 404:
-                # The server doesn't support all-tables API. Fallback to the old APIs instead.
-                schemas = chain(*(self.list_schemas(share) for share in shares))
-                return list(chain(*(self.list_tables(schema) for schema in schemas)))
-            else:
-                raise e

--- a/python/delta_sharing/sharing_client.py
+++ b/python/delta_sharing/sharing_client.py
@@ -1,0 +1,126 @@
+#
+# Copyright (C) 2021 The Delta Lake Project Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from itertools import chain
+from typing import BinaryIO, List, Optional, Sequence, TextIO, Union
+from pathlib import Path
+import requests
+
+from delta_sharing.protocol import DeltaSharingProfile, Schema, Share, Table
+from delta_sharing.rest_client import DataSharingRestClient
+
+from requests.exceptions import HTTPError
+
+
+class SharingClient:
+    """
+    A Delta Sharing client to query shares/schemas/tables from a Delta Sharing Server.
+
+    :param profile: The path to the profile file or a DeltaSharingProfile object.
+    :param session: An optional requests.Session object to use for HTTP requests.
+                    You can use this to customize proxy settings, authentication, etc.
+    """
+    def __init__(
+        self,
+        profile: Union[str, BinaryIO, TextIO, Path, DeltaSharingProfile],
+        session: Optional[requests.Session] = None
+    ):
+        if not isinstance(profile, DeltaSharingProfile):
+            profile = DeltaSharingProfile.read_from_file(profile)
+        self._profile = profile
+        self._rest_client = DataSharingRestClient(profile, session=session)
+
+    @property
+    def rest_client(self) -> DataSharingRestClient:
+        """
+        Get the underlying DataSharingRestClient used by this SharingClient.
+
+        :return: The DataSharingRestClient instance.
+        """
+        return self._rest_client
+
+    def __list_all_tables_in_share(self, share: Share) -> Sequence[Table]:
+        tables: List[Table] = []
+        page_token: Optional[str] = None
+        while True:
+            response = self._rest_client.list_all_tables(share=share, page_token=page_token)
+            tables.extend(response.tables)
+            page_token = response.next_page_token
+            if page_token is None or page_token == "":
+                return tables
+
+    def list_shares(self) -> Sequence[Share]:
+        """
+        List shares that can be accessed by you in a Delta Sharing Server.
+
+        :return: the shares that can be accessed.
+        """
+        shares: List[Share] = []
+        page_token: Optional[str] = None
+        while True:
+            response = self._rest_client.list_shares(page_token=page_token)
+            shares.extend(response.shares)
+            page_token = response.next_page_token
+            if page_token is None or page_token == "":
+                return shares
+
+    def list_schemas(self, share: Share) -> Sequence[Schema]:
+        """
+        List schemas in a share that can be accessed by you in a Delta Sharing Server.
+
+        :param share: the share to list.
+        :return: the schemas in a share.
+        """
+        schemas: List[Schema] = []
+        page_token: Optional[str] = None
+        while True:
+            response = self._rest_client.list_schemas(share=share, page_token=page_token)
+            schemas.extend(response.schemas)
+            page_token = response.next_page_token
+            if page_token is None or page_token == "":
+                return schemas
+
+    def list_tables(self, schema: Schema) -> Sequence[Table]:
+        """
+        List tables in a schema that can be accessed by you in a Delta Sharing Server.
+
+        :param schema: the schema to list.
+        :return: the tables in a schema.
+        """
+        tables: List[Table] = []
+        page_token: Optional[str] = None
+        while True:
+            response = self._rest_client.list_tables(schema=schema, page_token=page_token)
+            tables.extend(response.tables)
+            page_token = response.next_page_token
+            if page_token is None or page_token == "":
+                return tables
+
+    def list_all_tables(self) -> Sequence[Table]:
+        """
+        List all tables that can be accessed by you in a Delta Sharing Server.
+
+        :return: all tables that can be accessed.
+        """
+        shares = self.list_shares()
+        try:
+            return list(chain(*(self.__list_all_tables_in_share(share) for share in shares)))
+        except HTTPError as e:
+            if e.response.status_code == 404:
+                # The server doesn't support all-tables API. Fallback to the old APIs instead.
+                schemas = chain(*(self.list_schemas(share) for share in shares))
+                return list(chain(*(self.list_tables(schema) for schema in schemas)))
+            else:
+                raise e

--- a/python/delta_sharing/tests/test_reader.py
+++ b/python/delta_sharing/tests/test_reader.py
@@ -14,11 +14,9 @@
 # limitations under the License.
 #
 import pytest
-
+import pandas as pd
 from datetime import date
 from typing import Optional, Sequence
-
-import pandas as pd
 
 from delta_sharing.protocol import AddFile, AddCdcFile, CdfOptions, Metadata, RemoveFile, Table
 from delta_sharing.reader import DeltaSharingReader
@@ -38,6 +36,9 @@ def test_to_pandas_non_partitioned(tmp_path):
     pdf2.to_parquet(tmp_path / "pdf2.parquet")
 
     class RestClientMock:
+        def __init__(self, session=None):
+            self._session = session
+
         def list_files_in_table(
             self,
             table: Table,
@@ -91,6 +92,9 @@ def test_to_pandas_non_partitioned(tmp_path):
         def autoresolve_query_format(self, table: Table):
             return "parquet"
 
+        def get_session(self):
+            return self._session
+
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
     pdf = reader.to_pandas()
     expected = pd.concat([pdf1, pdf2]).reset_index(drop=True)
@@ -123,6 +127,9 @@ def test_to_pandas_partitioned(tmp_path):
     pdf2.to_parquet(tmp_path / "pdf2.parquet")
 
     class RestClientMock:
+        def __init__(self, session=None):
+            self._session = session
+
         def list_files_in_table(
             self,
             table: Table,
@@ -170,6 +177,9 @@ def test_to_pandas_partitioned(tmp_path):
         def autoresolve_query_format(self, table: Table):
             return "parquet"
 
+        def get_session(self):
+            return self._session
+
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
     pdf = reader.to_pandas()
 
@@ -190,6 +200,9 @@ def test_to_pandas_partitioned_different_schemas(tmp_path):
     pdf2.to_parquet(tmp_path / "pdf2.parquet")
 
     class RestClientMock:
+        def __init__(self, session=None):
+            self._session = session
+
         def list_files_in_table(
             self,
             table: Table,
@@ -238,6 +251,9 @@ def test_to_pandas_partitioned_different_schemas(tmp_path):
         def autoresolve_query_format(self, table: Table):
             return "parquet"
 
+        def get_session(self):
+            return self._session
+
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
     pdf = reader.to_pandas()
 
@@ -253,6 +269,9 @@ def test_to_pandas_partitioned_different_schemas(tmp_path):
 @pytest.mark.skipif(not ENABLE_INTEGRATION, reason=SKIP_MESSAGE)
 def test_to_pandas_empty(rest_client: DataSharingRestClient):
     class RestClientMock:
+        def __init__(self, session=None):
+            self._session = session
+
         def list_files_in_table(
             self,
             table: Table,
@@ -301,6 +320,9 @@ def test_to_pandas_empty(rest_client: DataSharingRestClient):
 
         def autoresolve_query_format(self, table: Table):
             return "parquet"
+
+        def get_session(self):
+            return self._session
 
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"), RestClientMock()  # type: ignore
@@ -356,6 +378,9 @@ def test_table_changes_to_pandas_non_partitioned(tmp_path):
     pdf4[DeltaSharingReader._commit_timestamp_col_name()] = timestamp4
 
     class RestClientMock:
+        def __init__(self, session=None):
+            self._session = session
+
         def list_table_changes(
             self, table: Table, cdfOptions: CdfOptions
         ) -> ListTableChangesResponse:
@@ -414,6 +439,9 @@ def test_table_changes_to_pandas_non_partitioned(tmp_path):
         def autoresolve_query_format(self, table: Table):
             return "parquet"
 
+        def get_session(self):
+            return self._session
+
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
     pdf = reader.table_changes_to_pandas(CdfOptions())
 
@@ -442,6 +470,9 @@ def test_table_changes_to_pandas_partitioned(tmp_path):
     pdf2[DeltaSharingReader._commit_timestamp_col_name()] = timestamp
 
     class RestClientMock:
+        def __init__(self, session=None):
+            self._session = session
+
         def list_table_changes(
             self,
             table: Table,
@@ -482,6 +513,9 @@ def test_table_changes_to_pandas_partitioned(tmp_path):
                 lines=None
             )
 
+        def get_session(self):
+            return self._session
+
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
     pdf = reader.table_changes_to_pandas(CdfOptions())
 
@@ -491,6 +525,9 @@ def test_table_changes_to_pandas_partitioned(tmp_path):
 
 def test_table_changes_empty(tmp_path):
     class RestClientMock:
+        def __init__(self, session=None):
+            self._session = session
+
         def list_table_changes(
             self, table: Table, cdfOptions: CdfOptions
         ) -> ListTableChangesResponse:
@@ -510,6 +547,9 @@ def test_table_changes_empty(tmp_path):
                 actions=[],
                 lines=None
             )
+
+        def get_session(self):
+            return self._session
 
     reader = DeltaSharingReader(Table("table_name", "share_name", "schema_name"), RestClientMock())
     pdf = reader.table_changes_to_pandas(CdfOptions())
@@ -565,6 +605,9 @@ def test_table_changes_to_pandas_non_partitioned_delta(tmp_path):
     pdf4[DeltaSharingReader._commit_timestamp_col_name()] = timestamp4
 
     class RestClientMock:
+        def __init__(self, session=None):
+            self._session = session
+
         def list_table_changes(
             self, table: Table, cdfOptions: CdfOptions
         ) -> ListTableChangesResponse:
@@ -575,7 +618,7 @@ def test_table_changes_to_pandas_non_partitioned_delta(tmp_path):
                 '{"metadata":{},"name":"a","nullable":true,"type":"long"},'
                 '{"metadata":{},"name":"b","nullable":true,"type":"string"}'
                 '],"type":"struct"}'
-            ).replace('"',r'\"')
+            ).replace('"', r'\"')
             lines = [
                 f'''{{
                     "protocol": {{
@@ -674,6 +717,9 @@ def test_table_changes_to_pandas_non_partitioned_delta(tmp_path):
 
         def remove_delta_format_header(self):
             return
+
+        def get_session(self):
+            return self._session
 
     reader = DeltaSharingReader(
         Table("table_name", "share_name", "schema_name"),


### PR DESCRIPTION
<div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances both Scala and Python Delta Sharing clients with improved HTTP configuration capabilities, supporting custom proxy settings, SSL configurations, and custom headers. The Python client now accepts an optional session parameter for streamlined connectivity, while test suites have been updated to validate these new configuration options.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 5
</div>